### PR TITLE
Implement Task Assignment Endpoints

### DIFF
--- a/src/main/java/com/flowforge/dto/request/AssignmentDTO.java
+++ b/src/main/java/com/flowforge/dto/request/AssignmentDTO.java
@@ -1,0 +1,18 @@
+package com.flowforge.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignmentDTO implements Serializable {
+    private Long taskId;
+    private String assigneeId;
+    private String assignedBy;
+    private String strategy;
+    private String reason;
+}

--- a/src/main/java/com/flowforge/dto/response/AssignmentResponse.java
+++ b/src/main/java/com/flowforge/dto/response/AssignmentResponse.java
@@ -1,0 +1,20 @@
+package com.flowforge.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignmentResponse {
+    private Long id;
+    private Long taskId;
+    private String assigneeId;
+    private String assignedBy;
+    private String strategy;
+    private String reason;
+    private LocalDateTime assignedAt;
+}

--- a/src/main/java/com/flowforge/repository/assignment/AssignmentRepository.java
+++ b/src/main/java/com/flowforge/repository/assignment/AssignmentRepository.java
@@ -1,0 +1,12 @@
+package com.flowforge.repository.assignment;
+
+import com.flowforge.model.Assignment;
+import com.flowforge.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
+
+    List<Assignment> findByTaskId(Long taskId);
+}

--- a/src/main/java/com/flowforge/resource/assignment/AssignmentResource.java
+++ b/src/main/java/com/flowforge/resource/assignment/AssignmentResource.java
@@ -1,0 +1,50 @@
+package com.flowforge.resource.assignment;
+
+import com.flowforge.dto.request.AssignmentDTO;
+import com.flowforge.dto.response.ApiResponseDto;
+import com.flowforge.dto.response.AssignmentResponse;
+import com.flowforge.service.assignment.AssignmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/assignments")
+@Tag(name = "Assignment resource", description = "Resource for Task Assignments")
+public class AssignmentResource {
+
+    private final AssignmentService assignmentService;
+
+    public AssignmentResource(AssignmentService assignmentService) {
+        this.assignmentService = assignmentService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Create Assignment", description = "Assign a task to a user")
+    @ApiResponse(responseCode = "201", description = "Assignment created successfully")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<ApiResponseDto<AssignmentResponse>> createAssignment(@RequestBody AssignmentDTO assignmentDTO) {
+        return assignmentService.createAssignment(assignmentDTO);
+    }
+
+    @GetMapping("/task/{taskId}")
+    @Operation(summary = "Get Task Assignments", description = "Retrieve all assignments for a task")
+    @ApiResponse(responseCode = "200", description = "Assignments retrieved successfully")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponseDto<List<AssignmentResponse>>> getAssignmentsByTaskId(@PathVariable Long taskId) {
+        return assignmentService.getAssignmentsByTaskId(taskId);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete Assignment", description = "Remove an assignment")
+    @ApiResponse(responseCode = "204", description = "Assignment deleted successfully")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> deleteAssignment(@PathVariable Long id) {
+        return assignmentService.deleteAssignment(id);
+    }
+}

--- a/src/main/java/com/flowforge/service/assignment/AssignmentService.java
+++ b/src/main/java/com/flowforge/service/assignment/AssignmentService.java
@@ -1,0 +1,14 @@
+package com.flowforge.service.assignment;
+
+import com.flowforge.dto.request.AssignmentDTO;
+import com.flowforge.dto.response.ApiResponseDto;
+import com.flowforge.dto.response.AssignmentResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface AssignmentService {
+    ResponseEntity<ApiResponseDto<AssignmentResponse>> createAssignment(AssignmentDTO assignmentDTO);
+    ResponseEntity<ApiResponseDto<List<AssignmentResponse>>> getAssignmentsByTaskId(Long taskId);
+    ResponseEntity<Void> deleteAssignment(Long id);
+}

--- a/src/main/java/com/flowforge/service/assignment/AssignmentServiceImpl.java
+++ b/src/main/java/com/flowforge/service/assignment/AssignmentServiceImpl.java
@@ -1,0 +1,103 @@
+package com.flowforge.service.assignment;
+
+import com.flowforge.dto.request.AssignmentDTO;
+import com.flowforge.dto.response.ApiResponseDto;
+import com.flowforge.dto.response.AssignmentResponse;
+import com.flowforge.exceptions.BadRequestException;
+import com.flowforge.exceptions.RecordNotFoundException;
+import com.flowforge.model.Assignment;
+import com.flowforge.model.Task;
+import com.flowforge.repository.assignment.AssignmentRepository;
+import com.flowforge.repository.task.TaskRepository;
+import com.flowforge.utils.EntityMapperUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class AssignmentServiceImpl implements AssignmentService {
+
+    private final AssignmentRepository assignmentRepository;
+    private final TaskRepository taskRepository;
+
+    public AssignmentServiceImpl(AssignmentRepository assignmentRepository, TaskRepository taskRepository) {
+        this.assignmentRepository = assignmentRepository;
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public ResponseEntity<ApiResponseDto<AssignmentResponse>> createAssignment(AssignmentDTO assignmentDTO) {
+
+        if (assignmentDTO == null) {
+            throw new BadRequestException("Assignment request body is invalid");
+        }
+
+        if (assignmentDTO.getTaskId() == null) {
+            throw new BadRequestException("Task ID is required");
+        }
+
+        if (assignmentDTO.getAssigneeId() == null || assignmentDTO.getAssigneeId().trim().isEmpty()) {
+            throw new BadRequestException("Assignee ID is required");
+        }
+
+        // Validate task exists
+        Optional<Task> taskOptional = taskRepository.findById(assignmentDTO.getTaskId());
+        if (taskOptional.isEmpty()) {
+            throw new RecordNotFoundException("Task with ID " + assignmentDTO.getTaskId() + " not found");
+        }
+
+        Assignment assignment = EntityMapperUtil.mapAssignmentDTOtoAssignment(assignmentDTO);
+        Assignment savedAssignment = assignmentRepository.save(assignment);
+        AssignmentResponse response = EntityMapperUtil.mapAssignmentToAssignmentResponse(savedAssignment);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponseDto<>(
+                        true,
+                        HttpStatus.CREATED.value(),
+                        HttpStatus.CREATED,
+                        "Success",
+                        response
+                ));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponseDto<List<AssignmentResponse>>> getAssignmentsByTaskId(Long taskId) {
+
+        // Validate task exists
+        Optional<Task> taskOptional = taskRepository.findById(taskId);
+        if (taskOptional.isEmpty()) {
+            throw new RecordNotFoundException("Task with ID " + taskId + " not found");
+        }
+
+        List<Assignment> assignments = assignmentRepository.findByTaskId(taskId);
+        List<AssignmentResponse> responses = assignments.stream()
+                .map(EntityMapperUtil::mapAssignmentToAssignmentResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(new ApiResponseDto<>(
+                true,
+                HttpStatus.OK.value(),
+                HttpStatus.OK,
+                "Success",
+                responses
+        ));
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteAssignment(Long id) {
+
+        Optional<Assignment> assignmentOptional = assignmentRepository.findById(id);
+        if (assignmentOptional.isEmpty()) {
+            throw new RecordNotFoundException("Assignment with ID " + id + " not found");
+        }
+
+        assignmentRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/flowforge/utils/EntityMapperUtil.java
+++ b/src/main/java/com/flowforge/utils/EntityMapperUtil.java
@@ -1,10 +1,14 @@
 package com.flowforge.utils;
 
+import com.flowforge.dto.request.AssignmentDTO;
 import com.flowforge.dto.request.TaskDTO;
 import com.flowforge.dto.request.UpdateTaskDTO;
+import com.flowforge.dto.response.AssignmentResponse;
 import com.flowforge.dto.response.TaskResponse;
+import com.flowforge.enums.AssignmentStrategy;
 import com.flowforge.enums.Priority;
 import com.flowforge.enums.TaskStatus;
+import com.flowforge.model.Assignment;
 import com.flowforge.model.Task;
 
 public class EntityMapperUtil {
@@ -72,6 +76,38 @@ public class EntityMapperUtil {
         }
 
         return taskResponse;
+    }
+
+    public static Assignment mapAssignmentDTOtoAssignment(AssignmentDTO assignmentDTO){
+        Assignment assignment = new Assignment();
+        assignment.setTaskId(assignmentDTO.getTaskId());
+        assignment.setAssignedBy(assignmentDTO.getAssignedBy());
+        assignment.setAssigneeId(assignmentDTO.getAssigneeId());
+        assignment.setReason(assignmentDTO.getReason());
+
+
+        if (assignmentDTO.getStrategy() != null) {
+            assignment.setStrategy(AssignmentStrategy.valueOf(assignmentDTO.getStrategy()));
+        }
+
+        return assignment;
+    }
+
+    public static AssignmentResponse mapAssignmentToAssignmentResponse(Assignment assignment){
+        AssignmentResponse assignmentResponse = new AssignmentResponse();
+        assignmentResponse.setId(assignment.getId());
+        assignmentResponse.setAssigneeId(assignment.getAssigneeId());
+        assignmentResponse.setAssignedBy(assignment.getAssignedBy());
+        assignmentResponse.setTaskId(assignment.getTaskId());
+        assignmentResponse.setAssignedAt(assignment.getAssignedAt());
+        assignmentResponse.setReason(assignment.getReason());
+
+
+        if (assignment.getStrategy() != null) {
+            assignmentResponse.setStrategy(assignment.getStrategy().label);
+        }
+
+        return assignmentResponse;
     }
 
 

--- a/src/test/java/com/flowforge/resource/assignment/AssignmentResourceTest.java
+++ b/src/test/java/com/flowforge/resource/assignment/AssignmentResourceTest.java
@@ -1,0 +1,234 @@
+package com.flowforge.resource.assignment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flowforge.config.SpringDataWebConfig;
+import com.flowforge.dto.request.AssignmentDTO;
+import com.flowforge.dto.response.ApiResponseDto;
+import com.flowforge.dto.response.AssignmentResponse;
+import com.flowforge.exceptions.BadRequestException;
+import com.flowforge.exceptions.GlobalExceptionHandler;
+import com.flowforge.exceptions.RecordNotFoundException;
+import com.flowforge.security.jwt.AuthTokenFilter;
+import com.flowforge.service.assignment.AssignmentService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import({SpringDataWebConfig.class, GlobalExceptionHandler.class})
+@WebMvcTest(controllers = AssignmentResource.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+public class AssignmentResourceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthTokenFilter authTokenFilter;
+
+    @MockitoBean
+    private AssignmentService assignmentService;
+
+    @BeforeEach
+    void forwardFilterChain() throws Exception {
+        doAnswer(invocation -> {
+            ServletRequest req = invocation.getArgument(0);
+            ServletResponse res = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(req, res);
+            return null;
+        }).when(authTokenFilter).doFilter(any(ServletRequest.class), any(ServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void createAssignment_shouldReturnCreatedAssignment() throws Exception {
+        // Arrange
+        AssignmentDTO assignmentDTO = new AssignmentDTO();
+        assignmentDTO.setTaskId(1L);
+        assignmentDTO.setAssigneeId("USER_123");
+        assignmentDTO.setAssignedBy("USER_456");
+        assignmentDTO.setStrategy("MANUAL");
+
+        AssignmentResponse assignmentResponse = new AssignmentResponse();
+        assignmentResponse.setId(1L);
+        assignmentResponse.setTaskId(1L);
+        assignmentResponse.setAssigneeId("USER_123");
+        assignmentResponse.setAssignedBy("USER_456");
+        assignmentResponse.setStrategy("MANUAL");
+        assignmentResponse.setAssignedAt(LocalDateTime.now());
+
+        ApiResponseDto<AssignmentResponse> apiResponse = new ApiResponseDto<>(
+                true,
+                HttpStatus.CREATED.value(),
+                HttpStatus.CREATED,
+                "Success",
+                assignmentResponse
+        );
+
+        when(assignmentService.createAssignment(any(AssignmentDTO.class)))
+                .thenReturn(ResponseEntity.status(HttpStatus.CREATED).body(apiResponse));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(assignmentDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(201))
+                .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.name()))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.taskId").value(1))
+                .andExpect(jsonPath("$.data.assigneeId").value("USER_123"));
+
+        verify(assignmentService, times(1)).createAssignment(any(AssignmentDTO.class));
+    }
+
+    @Test
+    void createAssignment_shouldReturn404_whenTaskNotFound() throws Exception {
+        // Arrange
+        AssignmentDTO assignmentDTO = new AssignmentDTO();
+        assignmentDTO.setTaskId(999L);
+        assignmentDTO.setAssigneeId("USER_123");
+
+        when(assignmentService.createAssignment(any(AssignmentDTO.class)))
+                .thenThrow(new RecordNotFoundException("Task with ID 999 not found"));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(assignmentDTO)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value("Task with ID 999 not found"));
+    }
+
+    @Test
+    void createAssignment_shouldReturn400_whenAssigneeIdIsEmpty() throws Exception {
+        // Arrange
+        AssignmentDTO assignmentDTO = new AssignmentDTO();
+        assignmentDTO.setTaskId(1L);
+        assignmentDTO.setAssigneeId("   ");
+
+        when(assignmentService.createAssignment(any(AssignmentDTO.class)))
+                .thenThrow(new BadRequestException("Assignee ID is required"));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(assignmentDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value("Assignee ID is required"));
+    }
+
+    @Test
+    void getAssignmentsByTaskId_shouldReturnAssignmentsList() throws Exception {
+        // Arrange
+        Long taskId = 1L;
+        AssignmentResponse assignment1 = new AssignmentResponse();
+        assignment1.setId(1L);
+        assignment1.setTaskId(taskId);
+        assignment1.setAssigneeId("USER_123");
+
+        AssignmentResponse assignment2 = new AssignmentResponse();
+        assignment2.setId(2L);
+        assignment2.setTaskId(taskId);
+        assignment2.setAssigneeId("USER_456");
+
+        ApiResponseDto<List<AssignmentResponse>> apiResponse = new ApiResponseDto<>(
+                true,
+                HttpStatus.OK.value(),
+                HttpStatus.OK,
+                "Success",
+                Arrays.asList(assignment1, assignment2)
+        );
+
+        when(assignmentService.getAssignmentsByTaskId(taskId))
+                .thenReturn(ResponseEntity.ok(apiResponse));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/assignments/task/{taskId}", taskId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.name()))
+                .andExpect(jsonPath("$.data[0].assigneeId").value("USER_123"))
+                .andExpect(jsonPath("$.data[1].assigneeId").value("USER_456"));
+
+        verify(assignmentService, times(1)).getAssignmentsByTaskId(taskId);
+    }
+
+    @Test
+    void getAssignmentsByTaskId_shouldReturn404_whenTaskNotFound() throws Exception {
+        // Arrange
+        Long taskId = 999L;
+        when(assignmentService.getAssignmentsByTaskId(taskId))
+                .thenThrow(new RecordNotFoundException("Task with ID 999 not found"));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/assignments/task/{taskId}", taskId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value("Task with ID 999 not found"));
+    }
+
+    @Test
+    void deleteAssignment_shouldReturnNoContent() throws Exception {
+        // Arrange
+        Long assignmentId = 1L;
+        when(assignmentService.deleteAssignment(assignmentId))
+                .thenReturn(ResponseEntity.noContent().build());
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/assignments/{id}", assignmentId))
+                .andExpect(status().isNoContent());
+
+        verify(assignmentService, times(1)).deleteAssignment(assignmentId);
+    }
+
+    @Test
+    void deleteAssignment_shouldReturn404_whenAssignmentNotFound() throws Exception {
+        // Arrange
+        Long assignmentId = 999L;
+        when(assignmentService.deleteAssignment(assignmentId))
+                .thenThrow(new RecordNotFoundException("Assignment with ID 999 not found"));
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/assignments/{id}", assignmentId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value("Assignment with ID 999 not found"));
+    }
+}

--- a/src/test/java/com/flowforge/service/assignment/AssignmentServiceTest.java
+++ b/src/test/java/com/flowforge/service/assignment/AssignmentServiceTest.java
@@ -1,0 +1,216 @@
+package com.flowforge.service.assignment;
+
+import com.flowforge.dto.request.AssignmentDTO;
+import com.flowforge.dto.response.ApiResponseDto;
+import com.flowforge.dto.response.AssignmentResponse;
+import com.flowforge.enums.AssignmentStrategy;
+import com.flowforge.exceptions.BadRequestException;
+import com.flowforge.exceptions.RecordNotFoundException;
+import com.flowforge.model.Assignment;
+import com.flowforge.model.Task;
+import com.flowforge.repository.assignment.AssignmentRepository;
+import com.flowforge.repository.task.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AssignmentServiceTest {
+
+    @Mock
+    private AssignmentRepository assignmentRepository;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @InjectMocks
+    private AssignmentServiceImpl assignmentService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createAssignment_shouldCreateAndReturnAssignment() {
+        // Arrange
+        AssignmentDTO assignmentDTO = new AssignmentDTO();
+        assignmentDTO.setTaskId(1L);
+        assignmentDTO.setAssigneeId("USER_123");
+        assignmentDTO.setAssignedBy("USER_456");
+        assignmentDTO.setStrategy("MANUAL");
+        assignmentDTO.setReason("Best fit");
+
+        Task task = new Task();
+        task.setId(1L);
+        task.setTitle("Test Task");
+
+        Assignment assignment = new Assignment();
+        assignment.setId(1L);
+        assignment.setTaskId(1L);
+        assignment.setAssigneeId("USER_123");
+        assignment.setAssignedBy("USER_456");
+        assignment.setStrategy(AssignmentStrategy.MANUAL);
+        assignment.setAssignedAt(LocalDateTime.now());
+
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(assignmentRepository.save(ArgumentMatchers.<Assignment>any())).thenReturn(assignment);
+
+        // Act
+        ResponseEntity<ApiResponseDto<AssignmentResponse>> response = assignmentService.createAssignment(assignmentDTO);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getSuccess());
+
+        AssignmentResponse assignmentResponse = response.getBody().getData();
+        assertNotNull(assignmentResponse);
+        assertEquals(1L, assignmentResponse.getId());
+        assertEquals(1L, assignmentResponse.getTaskId());
+        assertEquals("USER_123", assignmentResponse.getAssigneeId());
+
+        verify(taskRepository, times(1)).findById(1L);
+        verify(assignmentRepository, times(1)).save(ArgumentMatchers.isA(Assignment.class));
+    }
+
+    @Test
+    void createAssignment_shouldThrowException_whenTaskNotFound() {
+        // Arrange
+        AssignmentDTO assignmentDTO = new AssignmentDTO();
+        assignmentDTO.setTaskId(999L);
+        assignmentDTO.setAssigneeId("USER_123");
+
+        when(taskRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RecordNotFoundException exception = assertThrows(RecordNotFoundException.class, () -> {
+            assignmentService.createAssignment(assignmentDTO);
+        });
+
+        assertEquals("Task with ID 999 not found", exception.getMessage());
+        verify(taskRepository, times(1)).findById(999L);
+        verify(assignmentRepository, never()).save(ArgumentMatchers.isA(Assignment.class));
+    }
+
+    @Test
+    void createAssignment_shouldThrowException_whenAssigneeIdIsEmpty() {
+        // Arrange
+        AssignmentDTO assignmentDTO = new AssignmentDTO();
+        assignmentDTO.setTaskId(1L);
+        assignmentDTO.setAssigneeId("   ");
+
+        // Act & Assert
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            assignmentService.createAssignment(assignmentDTO);
+        });
+
+        assertEquals("Assignee ID is required", exception.getMessage());
+        verify(taskRepository, never()).findById(anyLong());
+        verify(assignmentRepository, never()).save(ArgumentMatchers.isA(Assignment.class));
+    }
+
+    @Test
+    void getAssignmentsByTaskId_shouldReturnAssignmentsList() {
+        // Arrange
+        Long taskId = 1L;
+        Task task = new Task();
+        task.setId(taskId);
+
+        Assignment assignment1 = new Assignment();
+        assignment1.setId(1L);
+        assignment1.setTaskId(taskId);
+        assignment1.setAssigneeId("USER_123");
+
+        Assignment assignment2 = new Assignment();
+        assignment2.setId(2L);
+        assignment2.setTaskId(taskId);
+        assignment2.setAssigneeId("USER_456");
+
+        when(taskRepository.findById(taskId)).thenReturn(Optional.of(task));
+        when(assignmentRepository.findByTaskId(taskId)).thenReturn(Arrays.asList(assignment1, assignment2));
+
+        // Act
+        ResponseEntity<ApiResponseDto<List<AssignmentResponse>>> response = assignmentService.getAssignmentsByTaskId(taskId);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getSuccess());
+
+        List<AssignmentResponse> assignments = response.getBody().getData();
+        assertNotNull(assignments);
+        assertEquals(2, assignments.size());
+        assertEquals("USER_123", assignments.get(0).getAssigneeId());
+        assertEquals("USER_456", assignments.get(1).getAssigneeId());
+
+        verify(taskRepository, times(1)).findById(taskId);
+        verify(assignmentRepository, times(1)).findByTaskId(taskId);
+    }
+
+    @Test
+    void getAssignmentsByTaskId_shouldThrowException_whenTaskNotFound() {
+        // Arrange
+        Long taskId = 999L;
+        when(taskRepository.findById(taskId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RecordNotFoundException exception = assertThrows(RecordNotFoundException.class, () -> {
+            assignmentService.getAssignmentsByTaskId(taskId);
+        });
+
+        assertEquals("Task with ID 999 not found", exception.getMessage());
+        verify(taskRepository, times(1)).findById(taskId);
+        verify(assignmentRepository, never()).findByTaskId(anyLong());
+    }
+
+    @Test
+    void deleteAssignment_shouldDeleteAssignment() {
+        // Arrange
+        Long assignmentId = 1L;
+        Assignment assignment = new Assignment();
+        assignment.setId(assignmentId);
+
+        when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
+
+        // Act
+        ResponseEntity<Void> response = assignmentService.deleteAssignment(assignmentId);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        verify(assignmentRepository, times(1)).findById(assignmentId);
+        verify(assignmentRepository, times(1)).deleteById(assignmentId);
+    }
+
+    @Test
+    void deleteAssignment_shouldThrowException_whenAssignmentNotFound() {
+        // Arrange
+        Long assignmentId = 999L;
+        when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RecordNotFoundException exception = assertThrows(RecordNotFoundException.class, () -> {
+            assignmentService.deleteAssignment(assignmentId);
+        });
+
+        assertEquals("Assignment with ID 999 not found", exception.getMessage());
+        verify(assignmentRepository, times(1)).findById(assignmentId);
+        verify(assignmentRepository, never()).deleteById(anyLong());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/nandom-gusen/task-service/issues/7

This PR implements REST endpoints for task assignment operations. Users can now assign tasks to team members, view assignment history, and remove assignments.

## Changes Made

### 1. New Endpoints
- **POST `/api/v1/assignments`** - Create assignment (201 CREATED)
- **GET `/api/v1/assignments/task/{taskId}`** - Get all assignments for task (200 OK)
- **DELETE `/api/v1/assignments/{id}`** - Remove assignment (204 NO CONTENT)

### 2. Validation
- Validates task exists before assignment
- Validates assigneeId is not empty
- Validates assignment strategy enum values

### 3. Files Created
- `AssignmentResource.java` - REST controller
- `AssignmentService.java` - Service interface
- `AssignmentServiceImpl.java` - Service implementation
- `AssignmentDTO.java` - Request DTO
- `AssignmentResponse.java` - Response DTO
- `AssignmentRepository` - JPA repository

## Example Usage

### Assign Task
**Request:**
```bash
POST /api/v1/assignments
Content-Type: application/json

{
  "taskId": 1,
  "assigneeId": "USER_123",
  "assignedBy": "USER_456",
  "strategy": "MANUAL",
  "reason": "Best fit for the task"
}
```

**Response (201 CREATED):**
```json
{
  "success": true,
  "code": 201,
  "status": "CREATED",
  "message": "Success",
  "data": {
    "id": 1,
    "taskId": 1,
    "assigneeId": "USER_123",
    "strategy": "MANUAL",
    "assignedAt": "2025-11-10T10:30:00"
  }
}
```

### Get Task Assignments
**Request:**
```bash
GET /api/v1/assignments/task/1
```

**Response (200 OK):**
```json
{
  "success": true,
  "code": 200,
  "status": "OK",
  "message": "Success",
  "data": [
    {
      "id": 1,
      "taskId": 1,
      "assigneeId": "USER_123",
      "assignedAt": "2025-11-10T10:30:00"
    }
  ]
}
```

### Unassign Task
**Request:**
```bash
DELETE /api/v1/assignments/1
```

**Response: 204 NO CONTENT**

## Error Handling

### Task Not Found
```json
{
  "success": false,
  "code": 404,
  "status": "NOT_FOUND",
  "message": "Task with ID 999 not found"
}
```

### Assignment Not Found
```json
{
  "success": false,
  "code": 404,
  "status": "NOT_FOUND",
  "message": "Assignment with ID 999 not found"
}
```

### Invalid AssigneeId
```json
{
  "success": false,
  "code": 400,
  "status": "BAD_REQUEST",
  "message": "Assignee ID is required"
}
```

## Technical Details
- Add `AssignmentRepository` JPA repository
- Leverages `TaskRepository` to validate task existence
- Manual validation in service layer for consistency
- All responses wrapped in `ApiResponseDto`
- Uses `EntityMapperUtil` for DTO ↔ Entity conversions


## Breaking Changes
None - New feature only
